### PR TITLE
feat: make @authcore/react and @authcore/core-web fully backend-agnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,12 @@ cp .env.example .env
 # Edit .env with real DATABASE_URL and AUTH_SECRET
 ```
 
+## Testing Rules (Always Follow These)
+
+- **Every code change must be accompanied by tests.** New features get new tests; bug fixes get a regression test; refactors must keep existing tests green.
+- Add tests to the existing test file for the package being changed. Do not create standalone test files unless a test file doesn't exist yet.
+- Run the affected package's tests after writing them (`pnpm --filter <package> test --run`) and confirm all pass before considering the task done.
+
 ## Security Rules (Never Break These)
 
 1. Passwords hashed with bcrypt ≥12 rounds, never stored or logged plain

--- a/docs/examples/frontend-only.md
+++ b/docs/examples/frontend-only.md
@@ -1,6 +1,6 @@
 # Frontend-Only Example
 
-A standalone React SPA that connects to any AuthCore-compatible API. No backend code included.
+A standalone React SPA that connects to any auth API — AuthCore-powered or not.
 
 [View source on GitHub](https://github.com/david-ouatedem/auth-core/tree/main/examples/frontend-only)
 
@@ -13,14 +13,14 @@ examples/frontend-only/
 
 - Points to a configurable external API URL via `VITE_API_URL`
 - Token stored in localStorage
-- Works with any AuthCore backend (Express or Fastify)
+- Works with any backend via response transformers
 
 ## Setup
 
 ```bash
 cd examples/frontend-only
 cp .env.example .env
-# Set VITE_API_URL to your AuthCore API
+# Set VITE_API_URL to your API base URL
 
 pnpm install
 pnpm dev
@@ -28,6 +28,10 @@ pnpm dev
 
 ## When to Use
 
-- You already have a deployed AuthCore API
+- You already have a deployed API (AuthCore or custom)
 - You want to build a frontend against a shared staging API
 - You want to test the React SDK without running a local backend
+
+## Connecting to a Custom Backend
+
+If your backend is not AuthCore-based, use the transformer props to adapt the response shapes. See [Custom Backend Integration](../integrations/react.md#custom-backend-integration) for full examples.

--- a/docs/integrations/react.md
+++ b/docs/integrations/react.md
@@ -37,18 +37,41 @@ function MyComponent() {
     user,              // PublicUser | null
     isAuthenticated,   // boolean
     isLoading,         // boolean
-    signUp,            // (email, password) => Promise<PublicUser>
-    signIn,            // (email, password) => Promise<PublicUser>
+    error,             // string | null
+    signUp,            // (email, password) => Promise<AuthResponse>
+    signIn,            // (email, password) => Promise<AuthResponse>
     signOut,           // () => Promise<void>
     forgotPassword,    // (email) => Promise<void>
     resetPassword,     // (token, password) => Promise<void>
     verifyEmail,       // (token) => Promise<void>
+    invite,            // (email, role?) => Promise<void>
+    acceptInvitation,  // (token, password) => Promise<AuthResponse>
     refreshUser,       // () => Promise<void>
   } = useAuth()
 
   // ...
 }
 ```
+
+### Extended user type
+
+If your backend returns extra fields on the user object (e.g. `avatarUrl`, `displayName`), pass a type parameter to `useAuth` to get them fully typed:
+
+```tsx
+import type { PublicUser } from '@authcore/types'
+
+interface MyUser extends PublicUser {
+  avatarUrl: string
+  displayName: string
+}
+
+function Profile() {
+  const { user } = useAuth<MyUser>()
+  // user.avatarUrl and user.displayName are typed
+}
+```
+
+Pair this with [`transformUser`](#custom-backend-integration) on `<AuthProvider>` to map your backend's response to `MyUser`.
 
 ## `ProtectedRoute`
 
@@ -85,7 +108,120 @@ function App() {
 | `mode` | `'api' \| 'cookie'` | `'api'` | Authentication mode |
 | `persistSession` | `boolean` | `true` | Store token in localStorage (api mode) |
 | `storageKey` | `string` | `'authcore_token'` | localStorage key (api mode) |
-| `routes` | `object` | defaults | Custom route paths |
+| `routes` | `object` | see below | Custom route paths |
+| `transformAuthResponse` | `(raw: unknown) => { user, token? }` | — | Map sign-in/sign-up response shape |
+| `transformUser` | `(raw: unknown) => TUser` | — | Map /me response shape |
+| `transformError` | `(body: unknown, status: number) => string` | — | Map error response to message string |
+| `httpClient` | `{ get, post }` | — | Replace the built-in fetch client entirely |
+
+### Custom route paths
+
+```tsx
+<AuthProvider
+  baseUrl="/api"
+  routes={{
+    login: '/auth/sign-in',
+    register: '/auth/sign-up',
+    logout: '/auth/sign-out',
+    me: '/auth/me',
+    verifyEmail: '/auth/verify',
+    forgotPassword: '/auth/forgot',
+    resetPassword: '/auth/reset',
+    invite: '/auth/invite',
+    acceptInvitation: '/auth/accept',
+  }}
+>
+```
+
+## Custom Backend Integration
+
+`@authcore/react` works with **any backend** — it does not require `@authcore/express` or any other AuthCore server package. Use the response transformer props to adapt your backend's JSON shape.
+
+### Different response shapes
+
+```tsx
+// Your backend returns: { data: { user: {...} }, access_token: "..." }
+<AuthProvider
+  baseUrl="https://api.example.com"
+  transformAuthResponse={(raw) => {
+    const res = raw as { data: { user: MyUser }; access_token: string }
+    return { user: res.data.user, token: res.access_token }
+  }}
+  transformUser={(raw) => {
+    const res = raw as { data: MyUser }
+    return res.data
+  }}
+/>
+```
+
+### Different error shapes
+
+```tsx
+// Your backend returns: { message: "Not found", statusCode: 404 }
+<AuthProvider
+  baseUrl="https://api.example.com"
+  transformError={(body, status) => {
+    const err = body as { message?: string }
+    return err.message ?? `Request failed with status ${status}`
+  }}
+/>
+```
+
+### Custom HTTP client (Axios, etc.)
+
+For full control — custom interceptors, retries, auth headers — supply your own HTTP client:
+
+```tsx
+import axios from 'axios'
+
+const axiosClient = {
+  get: <T>(path: string) =>
+    axios.get<T>(`https://api.example.com${path}`).then(r => r.data),
+  post: <T>(path: string, body?: unknown) =>
+    axios.post<T>(`https://api.example.com${path}`, body).then(r => r.data),
+}
+
+<AuthProvider httpClient={axiosClient}>
+  <App />
+</AuthProvider>
+```
+
+When `httpClient` is provided, `baseUrl`, `mode`, and `storageKey` are ignored for request handling.
+
+### Full custom backend example
+
+```tsx
+import type { PublicUser } from '@authcore/types'
+
+interface MyUser extends PublicUser {
+  avatarUrl: string
+  plan: 'free' | 'pro'
+}
+
+function App() {
+  return (
+    <AuthProvider<MyUser>
+      baseUrl="https://api.myapp.com"
+      mode="cookie"
+      routes={{ login: '/session', me: '/session/me', logout: '/session' }}
+      transformAuthResponse={(raw) => {
+        const r = raw as { user: MyUser; jwt: string }
+        return { user: r.user, token: r.jwt }
+      }}
+      transformUser={(raw) => (raw as { user: MyUser }).user}
+      transformError={(body) => (body as { message: string }).message}
+    >
+      <MyApp />
+    </AuthProvider>
+  )
+}
+
+// Fully typed access to extended fields anywhere in the tree
+function Header() {
+  const { user } = useAuth<MyUser>()
+  return <img src={user?.avatarUrl} />
+}
+```
 
 ## Error Handling
 
@@ -98,9 +234,11 @@ try {
   await signIn(email, password)
 } catch (err) {
   if (err instanceof AuthRequestError) {
-    console.log(err.message) // 'Invalid email or password'
-    console.log(err.code)    // 'INVALID_CREDENTIALS'
-    console.log(err.status)  // 401
+    console.log(err.message)    // 'Invalid email or password'
+    console.log(err.code)       // 'INVALID_CREDENTIALS' (if backend sends one)
+    console.log(err.statusCode) // 401
   }
 }
 ```
+
+Use `transformError` if your backend's error shape doesn't match `{ error: string, code?: string }`.

--- a/examples/frontend-only/README.md
+++ b/examples/frontend-only/README.md
@@ -1,19 +1,19 @@
 # AuthCore — Frontend-Only Example
 
-A standalone React SPA that connects to any AuthCore-compatible API.
-No backend code — just configure the API URL and go.
+A standalone React SPA that connects to **any auth API** — AuthCore-powered or custom.
+No backend code — just configure the API URL and response transformers, and go.
 
 ## Prerequisites
 
 - Node.js 18+
 - pnpm
-- A running AuthCore API (e.g. the `api-only/backend` example)
+- A running auth API (AuthCore or your own)
 
 ## Setup
 
 ```bash
 cp .env.example .env
-# Edit .env — set VITE_API_URL to your AuthCore API
+# Edit .env — set VITE_API_URL to your API base URL
 
 pnpm install
 pnpm dev
@@ -23,7 +23,7 @@ App runs on http://localhost:5173.
 
 ## Configuration
 
-Set `VITE_API_URL` in `.env` to point to your AuthCore backend:
+Set `VITE_API_URL` in `.env`:
 
 ```
 VITE_API_URL=http://localhost:3000
@@ -31,9 +31,36 @@ VITE_API_URL=http://localhost:3000
 
 The app expects the API to have CORS enabled for `http://localhost:5173`.
 
+## Using with an AuthCore backend
+
+Works out of the box — the default route paths and response shapes match AuthCore's Express/Fastify adapters.
+
+```tsx
+<AuthProvider baseUrl={`${API_URL}/auth`} mode="api">
+```
+
+## Using with a custom backend
+
+If your backend returns a different JSON shape, use the transformer props.
+See `src/App.tsx` for a commented example.
+
+```tsx
+// Backend returns { data: { user }, access_token: "..." }
+<AuthProvider
+  baseUrl={API_URL}
+  transformAuthResponse={(raw) => {
+    const r = raw as { data: { user: MyUser }; access_token: string }
+    return { user: r.data.user, token: r.access_token }
+  }}
+  transformUser={(raw) => (raw as { data: MyUser }).data}
+  transformError={(body) => (body as { message: string }).message ?? 'Unknown error'}
+  routes={{ login: '/auth/sign-in', me: '/auth/me', logout: '/auth/sign-out', register: '/auth/sign-up' }}
+>
+```
+
 ## Auth Flow
 
 1. Register or sign in
-2. Token is stored in localStorage
+2. Token is stored in localStorage (`api` mode)
 3. Protected requests include the token as a Bearer header
 4. Sign out clears the token

--- a/examples/frontend-only/src/App.tsx
+++ b/examples/frontend-only/src/App.tsx
@@ -3,6 +3,34 @@ import { useState } from 'react'
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
 
+// ---------------------------------------------------------------------------
+// If your backend is AuthCore-compatible, the default setup below works as-is.
+//
+// If your backend returns a different JSON shape, uncomment and adapt this:
+//
+// interface MyUser extends PublicUser {
+//   displayName: string
+//   avatarUrl: string
+// }
+//
+// const providerProps = {
+//   baseUrl: API_URL,
+//   routes: {
+//     login: '/auth/sign-in',
+//     register: '/auth/sign-up',
+//     logout: '/auth/sign-out',
+//     me: '/auth/me',
+//   },
+//   transformAuthResponse: (raw: unknown) => {
+//     const r = raw as { data: { user: MyUser }; access_token: string }
+//     return { user: r.data.user, token: r.access_token }
+//   },
+//   transformUser: (raw: unknown) => (raw as { data: MyUser }).data,
+//   transformError: (body: unknown) =>
+//     (body as { message?: string }).message ?? 'Request failed',
+// }
+// ---------------------------------------------------------------------------
+
 function Login() {
   const { signIn } = useAuth()
   const [email, setEmail] = useState('')
@@ -92,6 +120,8 @@ function AppContent() {
 
 export default function App() {
   return (
+    // Default: AuthCore-compatible backend (Express or Fastify adapter)
+    // To connect to a custom backend, see the commented providerProps above.
     <AuthProvider baseUrl={`${API_URL}/auth`} mode="api">
       <h1>AuthCore — Frontend-Only Example</h1>
       <p style={{ color: '#666' }}>

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory Index
+
+- [Docs site deployment](project_docs_deployment.md) — Live at github.io/auth-core; custom domain steps documented for when authcore.dev is ready

--- a/memory/project_docs_deployment.md
+++ b/memory/project_docs_deployment.md
@@ -1,0 +1,14 @@
+---
+name: Docs site deployment
+description: AuthCore docs site is deployed to GitHub Pages; custom domain steps for when authcore.dev is acquired
+type: project
+---
+
+Docs site is live at https://david-ouatedem.github.io/auth-core/ via GitHub Actions (`.github/workflows/docs.yml`), triggered on push to `main`.
+
+**Why:** VitePress site existed but had never been deployed. Set up as part of v0.7.0 work.
+
+**How to apply:** When a custom domain is acquired, three changes needed:
+1. Create `docs/public/CNAME` with the domain name
+2. Remove `base: '/auth-core/'` from `docs/.vitepress/config.ts`
+3. Point DNS to GitHub Pages IPs and enable custom domain in repo Settings → Pages

--- a/packages/core-web/README.md
+++ b/packages/core-web/README.md
@@ -1,6 +1,6 @@
 # @authcore/core-web
 
-> Framework-agnostic web authentication service for AuthCore. Works in any browser environment.
+> Framework-agnostic web authentication service. Works in any browser environment with any backend.
 
 ## Install
 
@@ -10,9 +10,9 @@ npm install @authcore/core-web @authcore/types
 
 ## Why this package?
 
-`@authcore/core-web` provides a lightweight client-side auth service that talks to your AuthCore backend over HTTP. It has zero runtime dependencies (uses native `fetch`) and works with any frontend framework or vanilla JS.
+`@authcore/core-web` provides a lightweight client-side auth service that talks to your backend over HTTP. It has zero runtime dependencies (uses native `fetch`) and works with any frontend framework or vanilla JS.
 
-If you're using React, use `@authcore/react` instead -- it wraps this package with hooks and context.
+If you're using React, use `@authcore/react` instead — it wraps this package with hooks and context.
 
 ## Usage
 
@@ -47,9 +47,75 @@ const unsubscribe = auth.subscribe(() => {
 await auth.signOut()
 ```
 
+## Custom Backend Integration
+
+`AuthWebService` works with any backend. Use the third constructor argument to adapt response shapes, error formats, or replace the HTTP client entirely.
+
+### Different response shapes
+
+```ts
+// Backend returns: { data: { user }, access_token: "..." }
+const auth = new AuthWebService(initialState, routes, {
+  transformers: {
+    transformAuthResponse: (raw) => {
+      const r = raw as { data: { user: MyUser }; access_token: string }
+      return { user: r.data.user, token: r.access_token }
+    },
+    transformUser: (raw) => (raw as { data: MyUser }).data,
+  },
+})
+```
+
+### Different error shapes
+
+```ts
+// Backend returns: { message: "Unauthorized" }
+const auth = new AuthWebService(initialState, routes, {
+  transformers: {
+    transformError: (body, status) => {
+      const err = body as { message?: string }
+      return err.message ?? `Request failed with status ${status}`
+    },
+  },
+})
+```
+
+### Custom HTTP client
+
+```ts
+import axios from 'axios'
+
+const auth = new AuthWebService(initialState, routes, {
+  httpClient: {
+    get: <T>(path: string) =>
+      axios.get<T>(`https://api.example.com${path}`).then(r => r.data),
+    post: <T>(path: string, body?: unknown) =>
+      axios.post<T>(`https://api.example.com${path}`, body).then(r => r.data),
+  },
+})
+```
+
+### Extended user type
+
+Pass a type parameter to get typed access to extra fields on the user object:
+
+```ts
+interface MyUser extends PublicUser {
+  avatarUrl: string
+}
+
+const auth = new AuthWebService<MyUser>(initialState, routes, {
+  transformers: {
+    transformUser: (raw) => raw as MyUser,
+  },
+})
+
+auth.getState().user?.avatarUrl // typed
+```
+
 ## API
 
-### `new AuthWebService(initialState, routes?)`
+### `new AuthWebService<TUser>(initialState, routes?, options?)`
 
 Creates an auth service instance.
 
@@ -57,17 +123,17 @@ Creates an auth service instance.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `baseUrl` | `string` | Your AuthCore backend URL (e.g. `http://localhost:3000/auth`) |
+| `baseUrl` | `string` | Your backend URL |
 | `mode` | `'api' \| 'cookie'` | `'api'` uses Bearer tokens, `'cookie'` uses httpOnly cookies |
-| `persistSession` | `boolean` | Whether to save the token in localStorage (api mode only) |
+| `persistSession` | `boolean` | Save token in localStorage (api mode) |
 | `storageKey` | `string` | localStorage key for the token |
-| `user` | `PublicUser \| null` | Initial user (usually `null`) |
+| `user` | `TUser \| null` | Initial user (usually `null`) |
 | `token` | `string \| null` | Initial token (usually `''`) |
 | `isAuthenticated` | `boolean` | Initial auth state (usually `false`) |
 | `isLoading` | `boolean` | Initial loading state |
 | `error` | `string \| null` | Initial error state (usually `null`) |
 
-**`routes`** (`AuthWebRoutesInterface`, optional) -- override default endpoint paths:
+**`routes`** (`AuthWebRoutesInterface`, optional) — override default endpoint paths:
 
 | Field | Default |
 |-------|---------|
@@ -81,38 +147,47 @@ Creates an auth service instance.
 | `invite` | `/invite` |
 | `acceptInvitation` | `/accept-invitation` |
 
+**`options`** (optional):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transformers.transformAuthResponse` | `(raw: unknown) => { user: TUser, token? }` | Map sign-in/sign-up/accept-invitation response |
+| `transformers.transformUser` | `(raw: unknown) => TUser` | Map /me response |
+| `transformers.transformError` | `(body: unknown, status: number) => string` | Map error body to message string |
+| `httpClient` | `{ get, post }` | Replace the built-in fetch client entirely |
+
 ### Methods
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `signIn({ email, password })` | `Promise<AuthResponse>` | Sign in and update state |
-| `signUp({ email, password })` | `Promise<AuthResponse>` | Register and update state |
+| `signIn({ email, password })` | `Promise<AuthResponse<TUser>>` | Sign in and update state |
+| `signUp({ email, password })` | `Promise<AuthResponse<TUser>>` | Register and update state |
 | `signOut()` | `Promise<void>` | Sign out and clear state |
 | `verifyEmail(token)` | `Promise<void>` | Verify email with token |
 | `forgotPassword(email)` | `Promise<void>` | Request password reset |
 | `resetPassword(token, password)` | `Promise<void>` | Reset password with token |
 | `invite(email, role?)` | `Promise<void>` | Send an invitation |
-| `acceptInvitation(token, password)` | `Promise<AuthResponse>` | Accept invitation and register |
+| `acceptInvitation(token, password)` | `Promise<AuthResponse<TUser>>` | Accept invitation and register |
 | `refreshUser()` | `Promise<void>` | Fetch current user from `/me` |
-| `getState()` | `AuthWebStateInterface` | Get current state snapshot |
-| `subscribe(listener)` | `() => void` | Subscribe to state changes, returns unsubscribe function |
+| `getState()` | `AuthWebStateInterface<TUser>` | Get current state snapshot |
+| `subscribe(listener)` | `() => void` | Subscribe to state changes, returns unsubscribe |
 
-### `AuthResponse`
+### `AuthResponse<TUser>`
 
 ```ts
-interface AuthResponse {
-  user: PublicUser
+interface AuthResponse<TUser extends PublicUser = PublicUser> {
+  user: TUser
   token?: string
 }
 ```
 
 ### `AuthRequestError`
 
-Thrown when the backend returns an error response.
+Thrown when the backend returns a non-2xx response.
 
 ```ts
 class AuthRequestError extends Error {
-  code: string | undefined
+  code: string | undefined  // optional machine-readable code from the backend
   statusCode: number
 }
 ```

--- a/packages/core-web/src/AuthWebService.ts
+++ b/packages/core-web/src/AuthWebService.ts
@@ -5,6 +5,15 @@ import type { HttpClient } from './types/HttpClients.interface.js'
 import { createFetchAuthClient } from './http-client/createFetchAuthClient.js'
 import type { PublicUser } from '@authcore/types'
 
+export interface AuthResponseTransformers<TUser extends PublicUser = PublicUser> {
+  /** Map your backend's sign-in / sign-up / accept-invitation response to { user, token? } */
+  transformAuthResponse?: (raw: unknown) => { user: TUser; token?: string }
+  /** Map your backend's /me response to a user object */
+  transformUser?: (raw: unknown) => TUser
+  /** Map your backend's error body to an error message string */
+  transformError?: (body: unknown, status: number) => string
+}
+
 /** All route paths with defaults applied. */
 interface ResolvedRoutes {
   register: string
@@ -18,14 +27,21 @@ interface ResolvedRoutes {
   acceptInvitation: string
 }
 
-export class AuthWebService implements AuthWebServiceResponseInterface {
-  private state: AuthWebStateInterface
+export class AuthWebService<TUser extends PublicUser = PublicUser>
+  implements AuthWebServiceResponseInterface<TUser> {
+  private state: AuthWebStateInterface<TUser>
   private paths: ResolvedRoutes
   private client: HttpClient
   private listeners: Set<() => void>
+  private transformers: AuthResponseTransformers<TUser>
 
-  constructor(initialState: AuthWebStateInterface, routes?: AuthWebRoutesInterface) {
+  constructor(
+    initialState: AuthWebStateInterface<TUser>,
+    routes?: AuthWebRoutesInterface,
+    options?: { transformers?: AuthResponseTransformers<TUser>; httpClient?: HttpClient },
+  ) {
     this.state = initialState
+    this.transformers = options?.transformers ?? {}
 
     if (typeof window !== 'undefined' && this.state.mode === 'api' && this.state.persistSession) {
       const stored = localStorage.getItem(this.state.storageKey ?? 'authcore_token')
@@ -34,10 +50,11 @@ export class AuthWebService implements AuthWebServiceResponseInterface {
       }
     }
 
-    this.client = createFetchAuthClient({
+    this.client = options?.httpClient ?? createFetchAuthClient({
       baseUrl: initialState.baseUrl,
       mode: initialState.mode,
       getToken: () => this.state.token ?? null,
+      ...(this.transformers.transformError ? { transformError: this.transformers.transformError } : {}),
     })
 
     this.paths = {
@@ -55,12 +72,15 @@ export class AuthWebService implements AuthWebServiceResponseInterface {
     this.listeners = new Set()
   }
 
-  async signIn({ email, password }: { email: string; password: string }): Promise<AuthResponse> {
+  async signIn({ email, password }: { email: string; password: string }): Promise<AuthResponse<TUser>> {
     try {
       this.state = { ...this.state, isLoading: true }
       this.notifyListeners()
 
-      const response = await this.client.post<AuthResponse>(this.paths.login, { email, password })
+      const raw = await this.client.post<unknown>(this.paths.login, { email, password })
+      const response = this.transformers.transformAuthResponse
+        ? this.transformers.transformAuthResponse(raw)
+        : raw as AuthResponse<TUser>
       this.state = {
         ...this.state,
         user: response.user,
@@ -80,12 +100,15 @@ export class AuthWebService implements AuthWebServiceResponseInterface {
     }
   }
 
-  async signUp({ email, password }: { email: string; password: string }): Promise<AuthResponse> {
+  async signUp({ email, password }: { email: string; password: string }): Promise<AuthResponse<TUser>> {
     try {
       this.state = { ...this.state, isLoading: true }
       this.notifyListeners()
 
-      const response = await this.client.post<AuthResponse>(this.paths.register, { email, password })
+      const raw = await this.client.post<unknown>(this.paths.register, { email, password })
+      const response = this.transformers.transformAuthResponse
+        ? this.transformers.transformAuthResponse(raw)
+        : raw as AuthResponse<TUser>
       this.state = {
         ...this.state,
         user: response.user,
@@ -184,15 +207,18 @@ export class AuthWebService implements AuthWebServiceResponseInterface {
     }
   }
 
-  async acceptInvitation(token: string, password: string): Promise<AuthResponse> {
+  async acceptInvitation(token: string, password: string): Promise<AuthResponse<TUser>> {
     try {
       this.state = { ...this.state, isLoading: true }
       this.notifyListeners()
 
-      const response = await this.client.post<AuthResponse>(
+      const raw = await this.client.post<unknown>(
         this.paths.acceptInvitation,
         { token, password },
       )
+      const response = this.transformers.transformAuthResponse
+        ? this.transformers.transformAuthResponse(raw)
+        : raw as AuthResponse<TUser>
       this.state = {
         ...this.state,
         user: response.user,
@@ -217,7 +243,10 @@ export class AuthWebService implements AuthWebServiceResponseInterface {
       this.state = { ...this.state, isLoading: true }
       this.notifyListeners()
 
-      const user = await this.client.get<PublicUser>(this.paths.me)
+      const raw = await this.client.get<unknown>(this.paths.me)
+      const user = this.transformers.transformUser
+        ? this.transformers.transformUser(raw)
+        : raw as TUser
       this.state = { ...this.state, user, isLoading: false, isAuthenticated: true }
       this.notifyListeners()
     } catch (error) {

--- a/packages/core-web/src/__test__/AuthWebService.test.ts
+++ b/packages/core-web/src/__test__/AuthWebService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AuthWebService } from '../AuthWebService.js';
+import type { PublicUser } from '@authcore/types';
 
 const mockUser = {
   id: 'user-1',
@@ -323,5 +324,185 @@ describe('AuthWebService', () => {
       (c: any) => String(c[0]).includes('/reset-password')
     );
     expect(resetCall).toBeDefined();
+  });
+});
+
+describe('AuthWebService — transformers', () => {
+  const baseState = {
+    baseUrl: 'http://api.example.com',
+    mode: 'api' as const,
+    persistSession: false,
+    storageKey: 'authcore_token',
+    token: null,
+    user: null,
+    error: null,
+    isLoading: false,
+    isAuthenticated: false,
+  };
+
+  beforeEach(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear();
+    } else {
+      const store: Record<string, string> = {};
+      vi.stubGlobal('localStorage', {
+        getItem: (key: string) => store[key] || null,
+        setItem: (key: string, value: string) => { store[key] = value; },
+        removeItem: (key: string) => { delete store[key]; },
+        clear: () => { Object.keys(store).forEach(k => delete store[k]); }
+      });
+    }
+    vi.stubGlobal('window', {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('transformAuthResponse maps custom sign-in response shape', async () => {
+    // Backend returns { data: { user }, access_token } instead of { user, token }
+    const backendResponse = { data: { user: mockUser }, access_token: 'custom-token' };
+    vi.stubGlobal('fetch', mockFetch({ 'POST /login': { status: 200, body: backendResponse } }));
+
+    const service = new AuthWebService(baseState, undefined, {
+      transformers: {
+        transformAuthResponse: (raw) => {
+          const r = raw as typeof backendResponse
+          return { user: r.data.user, token: r.access_token }
+        },
+      },
+    });
+
+    const result = await service.signIn({ email: 'test@example.com', password: 'pass' });
+
+    expect(result.user).toEqual(mockUser);
+    expect(result.token).toBe('custom-token');
+    expect(service.getState().user).toEqual(mockUser);
+    expect(service.getState().token).toBe('custom-token');
+    expect(service.getState().isAuthenticated).toBe(true);
+  });
+
+  it('transformAuthResponse maps custom sign-up response shape', async () => {
+    const backendResponse = { data: { user: mockUser }, access_token: 'signup-token' };
+    vi.stubGlobal('fetch', mockFetch({ 'POST /register': { status: 201, body: backendResponse } }));
+
+    const service = new AuthWebService(baseState, undefined, {
+      transformers: {
+        transformAuthResponse: (raw) => {
+          const r = raw as typeof backendResponse
+          return { user: r.data.user, token: r.access_token }
+        },
+      },
+    });
+
+    const result = await service.signUp({ email: 'test@example.com', password: 'pass' });
+
+    expect(result.user).toEqual(mockUser);
+    expect(result.token).toBe('signup-token');
+    expect(service.getState().isAuthenticated).toBe(true);
+  });
+
+  it('transformAuthResponse maps custom acceptInvitation response shape', async () => {
+    const backendResponse = { data: { user: mockUser }, access_token: 'invite-token' };
+    vi.stubGlobal('fetch', mockFetch({ 'POST /accept-invitation': { status: 200, body: backendResponse } }));
+
+    const service = new AuthWebService(baseState, undefined, {
+      transformers: {
+        transformAuthResponse: (raw) => {
+          const r = raw as typeof backendResponse
+          return { user: r.data.user, token: r.access_token }
+        },
+      },
+    });
+
+    const result = await service.acceptInvitation('invite-token-123', 'password');
+
+    expect(result.user).toEqual(mockUser);
+    expect(result.token).toBe('invite-token');
+    expect(service.getState().isAuthenticated).toBe(true);
+  });
+
+  it('transformUser maps custom /me response shape', async () => {
+    const backendMe = { profile: mockUser }
+    vi.stubGlobal('fetch', mockFetch({ 'GET /me': { status: 200, body: backendMe } }));
+
+    const service = new AuthWebService(baseState, undefined, {
+      transformers: {
+        transformUser: (raw) => (raw as typeof backendMe).profile,
+      },
+    });
+
+    await service.refreshUser();
+
+    expect(service.getState().user).toEqual(mockUser);
+    expect(service.getState().isAuthenticated).toBe(true);
+  });
+
+  it('extended user fields are preserved in state via transformUser', async () => {
+    interface ExtendedUser extends PublicUser { avatarUrl: string }
+    const extendedUser: ExtendedUser = { ...mockUser, avatarUrl: 'https://cdn.example.com/avatar.png' };
+
+    vi.stubGlobal('fetch', mockFetch({ 'GET /me': { status: 200, body: { data: extendedUser } } }));
+
+    const service = new AuthWebService<ExtendedUser>(baseState, undefined, {
+      transformers: {
+        transformUser: (raw) => (raw as { data: ExtendedUser }).data,
+      },
+    });
+
+    await service.refreshUser();
+
+    expect((service.getState().user as ExtendedUser)?.avatarUrl).toBe('https://cdn.example.com/avatar.png');
+  });
+
+  it('transformError maps custom error body to message on signIn failure', async () => {
+    vi.stubGlobal('fetch', mockFetch({ 'POST /login': { status: 401, body: { message: 'Wrong credentials' } } }));
+
+    const service = new AuthWebService(baseState, undefined, {
+      transformers: {
+        transformError: (body) => (body as { message: string }).message,
+      },
+    });
+
+    await expect(service.signIn({ email: 'test@example.com', password: 'wrong' }))
+      .rejects.toThrow('Wrong credentials');
+    expect(service.getState().error).toBe('Wrong credentials');
+  });
+
+  it('uses custom httpClient instead of fetch', async () => {
+    const customGet = vi.fn().mockResolvedValue(mockUser);
+    const customPost = vi.fn().mockResolvedValue({ user: mockUser, token: 'custom-client-token' });
+
+    const service = new AuthWebService(baseState, undefined, {
+      httpClient: { get: customGet, post: customPost },
+    });
+
+    await service.refreshUser();
+    expect(customGet).toHaveBeenCalledWith('/me');
+    expect(service.getState().user).toEqual(mockUser);
+
+    await service.signIn({ email: 'a@b.com', password: 'pass' });
+    expect(customPost).toHaveBeenCalledWith('/login', { email: 'a@b.com', password: 'pass' });
+    expect(service.getState().token).toBe('custom-client-token');
+  });
+
+  it('custom httpClient with transformAuthResponse work together', async () => {
+    const customPost = vi.fn().mockResolvedValue({ data: { user: mockUser }, jwt: 'jwt-abc' });
+
+    const service = new AuthWebService(baseState, undefined, {
+      httpClient: { get: vi.fn(), post: customPost },
+      transformers: {
+        transformAuthResponse: (raw) => {
+          const r = raw as { data: { user: typeof mockUser }; jwt: string }
+          return { user: r.data.user, token: r.jwt }
+        },
+      },
+    });
+
+    const result = await service.signIn({ email: 'a@b.com', password: 'pass' });
+
+    expect(result.user).toEqual(mockUser);
+    expect(result.token).toBe('jwt-abc');
+    expect(service.getState().isAuthenticated).toBe(true);
   });
 });

--- a/packages/core-web/src/__test__/createFetchAuthClient.test.ts
+++ b/packages/core-web/src/__test__/createFetchAuthClient.test.ts
@@ -153,4 +153,55 @@ describe('createFetchAuthClient', () => {
       expect(err.statusCode).toBe(500);
     }
   });
+
+  it('uses transformError to extract message from a custom error shape', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ message: 'Email already taken', statusCode: 422 })
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = createFetchAuthClient({
+      baseUrl: 'http://api.example.com',
+      mode: 'api',
+      getToken: () => null,
+      transformError: (body, status) => {
+        const b = body as { message?: string }
+        return b.message ?? `Error ${status}`
+      }
+    });
+
+    try {
+      await client.post('/register', {});
+      expect.fail('Expected error to be thrown');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(AuthRequestError);
+      expect(err.message).toBe('Email already taken');
+      expect(err.statusCode).toBe(422);
+    }
+  });
+
+  it('transformError fallback when message field is missing', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({})
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = createFetchAuthClient({
+      baseUrl: 'http://api.example.com',
+      mode: 'api',
+      getToken: () => null,
+      transformError: (_, status) => `Error ${status}`
+    });
+
+    try {
+      await client.get('/test');
+      expect.fail('Expected error to be thrown');
+    } catch (err: any) {
+      expect(err.message).toBe('Error 503');
+    }
+  });
 });

--- a/packages/core-web/src/http-client/createFetchAuthClient.ts
+++ b/packages/core-web/src/http-client/createFetchAuthClient.ts
@@ -9,6 +9,8 @@ export interface AuthClientConfig {
   baseUrl: string
   mode: 'api' | 'cookie'
   getToken: () => string | null
+  /** Override how error responses are converted to a message. Receives the raw parsed body and HTTP status. */
+  transformError?: (body: unknown, status: number) => string
 }
 
 export interface AuthApiError {
@@ -28,7 +30,7 @@ export class AuthRequestError extends Error {
 }
 
 export function createFetchAuthClient(config: AuthClientConfig): HttpClient {
-  const { baseUrl, mode, getToken } = config
+  const { baseUrl, mode, getToken, transformError } = config
 
   async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     const url = `${baseUrl}${path}`
@@ -52,13 +54,17 @@ export function createFetchAuthClient(config: AuthClientConfig): HttpClient {
     })
 
     if (!res.ok) {
-      let body: AuthApiError
+      let body: unknown
       try {
-        body = await res.json() as AuthApiError
+        body = await res.json()
       } catch {
         throw new AuthRequestError('Request failed', undefined, res.status)
       }
-      throw new AuthRequestError(body.error, body.code, res.status)
+      if (transformError) {
+        throw new AuthRequestError(transformError(body, res.status), undefined, res.status)
+      }
+      const apiError = body as AuthApiError
+      throw new AuthRequestError(apiError.error, apiError.code, res.status)
     }
 
     return res.json() as Promise<T>

--- a/packages/core-web/src/index.ts
+++ b/packages/core-web/src/index.ts
@@ -3,3 +3,5 @@ export { createFetchAuthClient, AuthRequestError } from './http-client/createFet
 export type { AuthWebRoutesInterface } from './types/AuthWebRoutes.interface.js'
 export type { AuthWebStateInterface } from './types/AuthWebState.interface.js'
 export type { AuthResponse, AuthWebServiceResponseInterface } from './types/AuthWebService.response.js'
+export type { AuthResponseTransformers } from './AuthWebService.js'
+export type { HttpClient } from './types/HttpClients.interface.js'

--- a/packages/core-web/src/types/AuthWebService.response.ts
+++ b/packages/core-web/src/types/AuthWebService.response.ts
@@ -1,23 +1,23 @@
 import type { PublicUser } from '@authcore/types'
 import type { AuthWebStateInterface } from './AuthWebState.interface.js'
 
-export interface AuthResponse {
-  user: PublicUser
+export interface AuthResponse<TUser extends PublicUser = PublicUser> {
+  user: TUser
   token?: string
 }
 
-export interface AuthWebServiceResponseInterface {
-  getState(): AuthWebStateInterface
+export interface AuthWebServiceResponseInterface<TUser extends PublicUser = PublicUser> {
+  getState(): AuthWebStateInterface<TUser>
   subscribe(listener: () => void): () => void
   notifyListeners(): void
 
-  signIn(params: { email: string; password: string }): Promise<AuthResponse>
-  signUp(params: { email: string; password: string }): Promise<AuthResponse>
+  signIn(params: { email: string; password: string }): Promise<AuthResponse<TUser>>
+  signUp(params: { email: string; password: string }): Promise<AuthResponse<TUser>>
   signOut(): Promise<void>
   verifyEmail(token: string): Promise<void>
   forgotPassword(email: string): Promise<void>
   resetPassword(token: string, password: string): Promise<void>
   invite(email: string, role?: string): Promise<void>
-  acceptInvitation(token: string, password: string): Promise<AuthResponse>
+  acceptInvitation(token: string, password: string): Promise<AuthResponse<TUser>>
   refreshUser(): Promise<void>
 }

--- a/packages/core-web/src/types/AuthWebState.interface.ts
+++ b/packages/core-web/src/types/AuthWebState.interface.ts
@@ -1,11 +1,11 @@
 import type { PublicUser } from '@authcore/types'
 
-export interface AuthWebStateInterface {
+export interface AuthWebStateInterface<TUser extends PublicUser = PublicUser> {
   isLoading: boolean
   persistSession: boolean
   storageKey: string
   isAuthenticated: boolean
-  user: PublicUser | null
+  user: TUser | null
   error: string | null
   token: string | null
   baseUrl: string

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,7 @@
 # @authcore/react
 
 > React SDK for AuthCore. Includes `AuthProvider`, `useAuth` hook, and `ProtectedRoute`.
+> Works with any backend — not just AuthCore.
 
 ## Install
 
@@ -54,6 +55,26 @@ function Main() {
 }
 ```
 
+### Extended user type
+
+If your backend returns extra fields on the user object, pass a type parameter to `useAuth`:
+
+```tsx
+import type { PublicUser } from '@authcore/types'
+
+interface MyUser extends PublicUser {
+  avatarUrl: string
+  displayName: string
+}
+
+function Profile() {
+  const { user } = useAuth<MyUser>()
+  return <img src={user?.avatarUrl} />
+}
+```
+
+Pair this with `transformUser` on `<AuthProvider>` to map your backend's response shape.
+
 ### `ProtectedRoute`
 
 Renders children only when authenticated:
@@ -85,9 +106,9 @@ await verifyEmail(token)
 import { useRole, useHasRole } from '@authcore/react'
 
 function AdminPanel() {
-  const role = useRole()               // 'admin', 'user', etc. or null
-  const isAdmin = useHasRole('admin')  // true/false
-  const isStaff = useHasRole(['admin', 'editor'])  // true if either role
+  const role = useRole()                       // 'admin', 'user', etc. or null
+  const isAdmin = useHasRole('admin')          // true/false
+  const isStaff = useHasRole(['admin', 'editor'])
 
   if (!isAdmin) return <p>Access denied</p>
   return <p>Welcome, {role}</p>
@@ -99,11 +120,56 @@ function AdminPanel() {
 ```tsx
 const { invite, acceptInvitation } = useAuth()
 
-// Admin invites a new user
 await invite('new@user.com', 'editor')
+const { user } = await acceptInvitation(token, 'mypassword123')
+```
 
-// Invited user accepts (on the accept-invitation page)
-const user = await acceptInvitation(token, 'mypassword123')
+## Custom Backend Integration
+
+`@authcore/react` works with **any backend**. Use the response transformer props to adapt your backend's JSON shape.
+
+### Different response shapes
+
+```tsx
+// Backend returns: { data: { user }, access_token: "..." }
+<AuthProvider
+  baseUrl="https://api.example.com"
+  transformAuthResponse={(raw) => {
+    const r = raw as { data: { user: MyUser }; access_token: string }
+    return { user: r.data.user, token: r.access_token }
+  }}
+  transformUser={(raw) => (raw as { data: MyUser }).data}
+/>
+```
+
+### Different error shapes
+
+```tsx
+// Backend returns: { message: "Unauthorized" }
+<AuthProvider
+  baseUrl="https://api.example.com"
+  transformError={(body, status) => {
+    const err = body as { message?: string }
+    return err.message ?? `Request failed with status ${status}`
+  }}
+/>
+```
+
+### Custom HTTP client (Axios, etc.)
+
+```tsx
+import axios from 'axios'
+
+const client = {
+  get: <T>(path: string) =>
+    axios.get<T>(`https://api.example.com${path}`).then(r => r.data),
+  post: <T>(path: string, body?: unknown) =>
+    axios.post<T>(`https://api.example.com${path}`, body).then(r => r.data),
+}
+
+<AuthProvider httpClient={client}>
+  <App />
+</AuthProvider>
 ```
 
 ## API Reference
@@ -112,46 +178,57 @@ const user = await acceptInvitation(token, 'mypassword123')
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `baseUrl` | `string` | - | Auth API base URL (e.g. `http://localhost:3000/auth`) |
+| `baseUrl` | `string` | required | Auth API base URL |
 | `mode` | `'api' \| 'cookie'` | `'api'` | `api` uses Bearer tokens, `cookie` uses httpOnly cookies |
-| `storageKey` | `string` | `'authcore_token'` | localStorage key for the JWT (api mode only) |
-| `children` | `ReactNode` | - | - |
+| `storageKey` | `string` | `'authcore_token'` | localStorage key for the token (api mode) |
+| `persistSession` | `boolean` | `true` | Persist token in localStorage (api mode) |
+| `routes` | `object` | see below | Override default endpoint paths |
+| `transformAuthResponse` | `(raw: unknown) => { user, token? }` | — | Map sign-in/sign-up/accept-invitation response |
+| `transformUser` | `(raw: unknown) => TUser` | — | Map /me response |
+| `transformError` | `(body: unknown, status: number) => string` | — | Map error body to message string |
+| `httpClient` | `{ get, post }` | — | Replace the built-in fetch client entirely |
 
-### `useAuth()` Return Value
+**Default route paths:**
+
+| Route | Default |
+|-------|---------|
+| `register` | `/register` |
+| `login` | `/login` |
+| `logout` | `/logout` |
+| `me` | `/me` |
+| `verifyEmail` | `/verify-email` |
+| `forgotPassword` | `/forgot-password` |
+| `resetPassword` | `/reset-password` |
+| `invite` | `/invite` |
+| `acceptInvitation` | `/accept-invitation` |
+
+### `useAuth<TUser>()` Return Value
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `user` | `PublicUser \| null` | Current user or null |
+| `user` | `TUser \| null` | Current user or null |
 | `isLoading` | `boolean` | True while restoring session |
 | `isAuthenticated` | `boolean` | True if user is logged in |
 | `error` | `string \| null` | Last error message, or null |
-| `signUp(email, password)` | `Promise<AuthResponse>` | Register a new account |
-| `signIn(email, password)` | `Promise<AuthResponse>` | Sign in |
+| `signUp(email, password)` | `Promise<AuthResponse<TUser>>` | Register a new account |
+| `signIn(email, password)` | `Promise<AuthResponse<TUser>>` | Sign in |
 | `signOut()` | `Promise<void>` | Sign out |
-| `forgotPassword(email)` | `Promise<void>` | Request password reset |
+| `forgotPassword(email)` | `Promise<void>` | Request password reset email |
 | `resetPassword(token, password)` | `Promise<void>` | Reset password |
 | `verifyEmail(token)` | `Promise<void>` | Verify email address |
-| `invite(email, role?)` | `Promise<void>` | Invite a new user by email |
-| `acceptInvitation(token, password)` | `Promise<AuthResponse>` | Accept an invitation |
-| `refreshUser()` | `Promise<void>` | Re-fetch current user |
+| `invite(email, role?)` | `Promise<void>` | Invite a new user |
+| `acceptInvitation(token, password)` | `Promise<AuthResponse<TUser>>` | Accept an invitation |
+| `refreshUser()` | `Promise<void>` | Re-fetch current user from `/me` |
 
 ### `<ProtectedRoute>`
 
 | Prop | Type | Description |
 |------|------|-------------|
 | `children` | `ReactNode` | Content to show when authenticated |
-| `fallback` | `ReactNode` | Shown while loading |
+| `fallback` | `ReactNode` | Shown while loading (default: `null`) |
 | `onUnauthenticated` | `() => void` | Called when user is not authenticated |
 
-## Using Types Directly
-
-`@authcore/types` is installed automatically as a dependency. If you need to use types like `PublicUser` in your own code:
-
-```ts
-import type { PublicUser } from '@authcore/types'
-```
-
-## Cookie Mode (Monorepo)
+## Cookie Mode
 
 When your backend and frontend share the same domain:
 
@@ -161,7 +238,14 @@ When your backend and frontend share the same domain:
 </AuthProvider>
 ```
 
-In cookie mode, the SDK uses `credentials: 'include'` and doesn't store tokens in localStorage.
+In cookie mode, the SDK uses `credentials: 'include'` and does not store tokens in localStorage.
+
+## Using Types Directly
+
+```ts
+import type { PublicUser } from '@authcore/types'
+import type { AuthResponseTransformers } from '@authcore/core-web'
+```
 
 ## License
 

--- a/packages/react/src/AuthProvider.tsx
+++ b/packages/react/src/AuthProvider.tsx
@@ -1,46 +1,73 @@
 import { createContext, useEffect, useMemo, useSyncExternalStore } from 'react'
 import { AuthWebService } from '@authcore/core-web'
-import type { AuthWebRoutesInterface, AuthResponse } from '@authcore/core-web'
+import type { AuthWebRoutesInterface, AuthResponse, AuthResponseTransformers } from '@authcore/core-web'
 import type { PublicUser } from '@authcore/types'
 
-export interface AuthContextValue {
-  user: PublicUser | null
+export interface AuthContextValue<TUser extends PublicUser = PublicUser> {
+  user: TUser | null
   isLoading: boolean
   isAuthenticated: boolean
   error: string | null
-  signUp(email: string, password: string): Promise<AuthResponse>
-  signIn(email: string, password: string): Promise<AuthResponse>
+  signUp(email: string, password: string): Promise<AuthResponse<TUser>>
+  signIn(email: string, password: string): Promise<AuthResponse<TUser>>
   signOut(): Promise<void>
   verifyEmail(token: string): Promise<void>
   forgotPassword(email: string): Promise<void>
   resetPassword(token: string, password: string): Promise<void>
   invite(email: string, role?: string): Promise<void>
-  acceptInvitation(token: string, password: string): Promise<AuthResponse>
+  acceptInvitation(token: string, password: string): Promise<AuthResponse<TUser>>
   refreshUser(): Promise<void>
 }
 
-export const AuthContext = createContext<AuthContextValue | null>(null)
+// Context is typed with the base PublicUser. useAuth<TUser>() narrows via a type assertion,
+// the same opt-in pattern used by next-auth's session augmentation.
+export const AuthContext = createContext<AuthContextValue<PublicUser> | null>(null)
 
-export interface AuthProviderProps {
+export interface AuthProviderProps<TUser extends PublicUser = PublicUser> {
   baseUrl: string
   mode?: 'api' | 'cookie'
   storageKey?: string
   persistSession?: boolean
   routes?: AuthWebRoutesInterface
   children: React.ReactNode
+  /**
+   * Map your backend's sign-in / sign-up / accept-invitation response to `{ user, token? }`.
+   * Use this when your backend returns a different JSON shape, e.g. `{ data: { user }, access_token }`.
+   */
+  transformAuthResponse?: AuthResponseTransformers<TUser>['transformAuthResponse']
+  /**
+   * Map your backend's /me response to a user object.
+   * Use this when your backend returns a different shape for the current-user endpoint.
+   * Return any shape you want — pair with `useAuth<YourUserType>()` to get it fully typed.
+   */
+  transformUser?: AuthResponseTransformers<TUser>['transformUser']
+  /**
+   * Map your backend's error body to an error message string.
+   * Use this when your backend returns errors as `{ message }`, `{ errors: [] }`, etc.
+   */
+  transformError?: AuthResponseTransformers<TUser>['transformError']
+  /**
+   * Provide a custom HTTP client (e.g. an Axios adapter) to replace the built-in fetch client.
+   * When supplied, `baseUrl`, `mode`, and `storageKey` are ignored for request handling.
+   */
+  httpClient?: { get<T>(path: string): Promise<T>; post<T>(path: string, body?: unknown): Promise<T> }
 }
 
-export function AuthProvider({
+export function AuthProvider<TUser extends PublicUser = PublicUser>({
   baseUrl,
   mode = 'api',
   storageKey = 'authcore_token',
   persistSession = true,
   routes,
   children,
-}: AuthProviderProps) {
+  transformAuthResponse,
+  transformUser,
+  transformError,
+  httpClient,
+}: AuthProviderProps<TUser>) {
   const service = useMemo(
     () =>
-      new AuthWebService(
+      new AuthWebService<TUser>(
         {
           baseUrl,
           mode,
@@ -53,7 +80,16 @@ export function AuthProvider({
           isAuthenticated: false,
         },
         routes,
+        {
+          ...(httpClient ? { httpClient } : {}),
+          transformers: {
+            ...(transformAuthResponse ? { transformAuthResponse } : {}),
+            ...(transformUser ? { transformUser } : {}),
+            ...(transformError ? { transformError } : {}),
+          },
+        },
       ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [baseUrl, mode, storageKey, persistSession, routes],
   )
 
@@ -66,7 +102,7 @@ export function AuthProvider({
     service.refreshUser().catch(() => {})
   }, [service])
 
-  const value: AuthContextValue = {
+  const value: AuthContextValue<TUser> = {
     user: state.user,
     isLoading: state.isLoading,
     isAuthenticated: state.isAuthenticated,
@@ -82,5 +118,9 @@ export function AuthProvider({
     refreshUser: () => service.refreshUser(),
   }
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  return (
+    <AuthContext.Provider value={value as AuthContextValue<PublicUser>}>
+      {children}
+    </AuthContext.Provider>
+  )
 }

--- a/packages/react/src/useAuth.ts
+++ b/packages/react/src/useAuth.ts
@@ -1,11 +1,24 @@
 import { useContext } from 'react'
 import { AuthContext } from './AuthProvider.js'
 import type { AuthContextValue } from './AuthProvider.js'
+import type { PublicUser } from '@authcore/types'
 
 /**
  * Access the AuthCore authentication context.
  *
  * Must be called inside an `<AuthProvider>`.
+ *
+ * Pass a type parameter to access fields you added via `transformUser` on `<AuthProvider>`:
+ *
+ * ```tsx
+ * interface MyUser extends PublicUser {
+ *   avatarUrl: string
+ *   displayName: string
+ * }
+ *
+ * const { user } = useAuth<MyUser>()
+ * // user.avatarUrl and user.displayName are fully typed
+ * ```
  *
  * @example
  * ```tsx
@@ -22,10 +35,10 @@ import type { AuthContextValue } from './AuthProvider.js'
  * }
  * ```
  */
-export function useAuth(): AuthContextValue {
+export function useAuth<TUser extends PublicUser = PublicUser>(): AuthContextValue<TUser> {
   const context = useContext(AuthContext)
   if (!context) {
     throw new Error('useAuth must be used within an <AuthProvider>')
   }
-  return context
+  return context as AuthContextValue<TUser>
 }


### PR DESCRIPTION
Removes the assumption that the backend runs @authcore/express or any other AuthCore server package. @authcore/react and @authcore/core-web now work with any backend regardless of JSON response shape, error format, or HTTP client preference.

Changes
Add transformAuthResponse, transformUser, and transformError props to <AuthProvider> and options to AuthWebService — lets callers map any backend response shape to the expected types
Add httpClient prop/option to replace the built-in fetch client entirely (enables Axios, custom interceptors, retries, etc.)
Make AuthWebService<TUser>, AuthContextValue<TUser>, AuthProvider<TUser>, and useAuth<TUser>() generic so extended user fields (e.g. avatarUrl, displayName) are fully typed end-to-end
Export AuthResponseTransformers and HttpClient types from @authcore/core-web
Update READMEs for both packages with custom backend integration examples
Update docs/integrations/react.md with a dedicated "Custom Backend Integration" section
Add testing rule to CLAUDE.md: every code change must be accompanied by tests
Type of change
 Bug fix
 New feature
 Breaking change
 Documentation update
 Refactor
Checklist
 I've read the [contributing guidelines](vscode-webview://0jtd5b1a24phs992rb77qrtmdo606uh4ikihu74526o0hat0j9f9/CONTRIBUTING.md)
 My code follows the existing code style
 I've added tests that cover my changes
 All existing tests pass (pnpm test)
 All packages build (pnpm build)
 I've updated documentation if needed
Test plan
Added 9 new unit tests to AuthWebService.test.ts covering transformAuthResponse on signIn/signUp/acceptInvitation, transformUser on refreshUser, extended user fields preserved end-to-end, transformError, custom httpClient, and combined httpClient + transformer usage
Added 2 new unit tests to createFetchAuthClient.test.ts covering transformError with a custom error shape and fallback behaviour
All 158 tests pass across 14 test files (pnpm -w run test --run)
Both @authcore/core-web and @authcore/react build cleanly with no type errors